### PR TITLE
Added manifest file to define what gets packaged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+/.idea/
+*.pyc
+*.db
+/project/
+/dist
+*.egg-info
+.DS_Store
+/build
+*#
+*~
+.coverage
+/htmlcov/
+*.orig
+tmp
+venv/
+.venv/
+
+# Sphinx documentation
+docs/_build/
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include djangocms_gallery *
+recursive-exclude * *.pyc __pycache__ .DS_Store
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setuptools.setup(
      long_description=long_description,
      long_description_content_type="text/markdown",
      url="https://github.com/svandeneertwegh/djangocms-gallery",
-     packages=setuptools.find_packages(),
-     include_package_data = True,
+     packages=["djangocms_gallery"],
+     include_package_data=True,
      install_requires=[
           'django-cms>=3.9.0',
           'django-filer>=2.1rc2'


### PR DESCRIPTION
This adds a `MANIFEST.in` file which defines what gets packaged by setuptools.

I've also added a gitignore file which is vital early in a project to make sure the repo is kept clean.